### PR TITLE
Allow setting http_port through `$PORT`

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -10,4 +10,6 @@ WORKDIR /home/registrator
 RUN julia -e "using Pkg; Pkg.add(PackageSpec(url=\"https://github.com/JuliaComputing/Registrator.jl\"))"
 ADD scripts /home/registrator
 
+# Comment out ENTRYPOINT and uncomment the CMD line if you are using Heroku.
 ENTRYPOINT ["/bin/bash", "run.sh"]
+# CMD /bin/bash run.sh

--- a/image/scripts/sample.toml
+++ b/image/scripts/sample.toml
@@ -1,4 +1,5 @@
 [server]
+# Remove http_port to make the server use ENV["PORT"]. Heroku users must do this.
 http_port = 8001
 http_ip = "0.0.0.0"
 stop_file = "/tmp/stopregistrator"

--- a/src/Server.jl
+++ b/src/Server.jl
@@ -895,7 +895,7 @@ function request_processor()
     recover("request_processor", keep_running, do_action, handle_exception)
 end
 
-function github_webhook(http_ip=config["server"]["http_ip"], http_port=config["server"]["http_port"])
+function github_webhook(http_ip=config["server"]["http_ip"], http_port=get(config["server"], "http_port", get(ENV, "PORT", 8001)))
     auth = get_jwt_auth()
     trigger = Regex("@$(config["registrator"]["trigger"]) (.*?)\$")
     listener = GitHub.CommentListener(comment_handler, trigger; check_collab=false, auth=auth, secret=config["github"]["secret"])

--- a/src/Server.jl
+++ b/src/Server.jl
@@ -895,7 +895,7 @@ function request_processor()
     recover("request_processor", keep_running, do_action, handle_exception)
 end
 
-function github_webhook(http_ip=config["server"]["http_ip"], http_port=get(config["server"], "http_port", get(ENV, "PORT", 8001)))
+function github_webhook(http_ip=config["server"]["http_ip"], http_port=get(config["server"], "http_port", parse(Int, get(ENV, "PORT", "8001"))))
     auth = get_jwt_auth()
     trigger = Regex("@$(config["registrator"]["trigger"]) (.*?)\$")
     listener = GitHub.CommentListener(comment_handler, trigger; check_collab=false, auth=auth, secret=config["github"]["secret"])


### PR DESCRIPTION
@nkottary As discussed in #39, this PR implements the Server getting its port from `ENV["PORT"]` if `http_port` is not set in the config.toml. If neither is set, then the server will use a default port of 8001.

This is useful for deploying places where you don't control the port number you get, like Heroku, which sets a value for `$PORT` when the app spins up. 