### PR TITLE
Make the server use the registry_deps option when calling the `register` function

### DIFF
--- a/image/scripts/sample.toml
+++ b/image/scripts/sample.toml
@@ -26,6 +26,7 @@ set_status = true
 enc_key = "1234567890123456"
 disable_pull_request_trigger = false
 disable_approval_process = false
+registry_deps = ["https://github.com/JuliaRegistries/General"]
 
 [slack]
 alert = false

--- a/src/Server.jl
+++ b/src/Server.jl
@@ -815,7 +815,7 @@ function handle_register(rp::RequestParams, target_registry::Dict{String,Any})
     if pp.cparams.isvalid && pp.cparams.error == nothing
         rbrn = register(pp.cloneurl, Pkg.Types.read_project(copy(IOBuffer(pp.projectfile_contents))), pp.tree_sha;
             registry=target_registry["repo"],
-            registry_deps=config["registrator"]["registry_deps"],
+            registry_deps=get(config["registrator"], "registry_deps", String[]),
             push=true,
             gitconfig=Dict("user.name"=>config["github"]["user"], "user.email"=>config["github"]["email"]))
         if rbrn.error !== nothing

--- a/src/Server.jl
+++ b/src/Server.jl
@@ -815,6 +815,7 @@ function handle_register(rp::RequestParams, target_registry::Dict{String,Any})
     if pp.cparams.isvalid && pp.cparams.error == nothing
         rbrn = register(pp.cloneurl, Pkg.Types.read_project(copy(IOBuffer(pp.projectfile_contents))), pp.tree_sha;
             registry=target_registry["repo"],
+            registry_deps=config["registrator"]["registry_deps"],
             push=true,
             gitconfig=Dict("user.name"=>config["github"]["user"], "user.email"=>config["github"]["email"]))
         if rbrn.error !== nothing


### PR DESCRIPTION
This PR adds an option to the config:

```
[registrator]
registry_deps = ["https://github.com/JuliaRegistries/General"]
```

That can be extended to add more registries that can be used for dependency checking. This is for situations where you are registering a package to your registry, which has a dependency in a different registry. Which might be frequently for non-General registries: It's likely non-General registries will have packages that have dependencies in General).

By default, General is already listed there in the sample config.