### PR TITLE
Make clear that the tag should be made after merge

### DIFF
--- a/src/Server.jl
+++ b/src/Server.jl
@@ -776,11 +776,12 @@ $enc_meta
     cbody = """
 Registration pull request $msg: [$(repo)/$(pr.number)]($(pr.html_url))
 
-Optionally, you can create a tag on this repository for the above registration.
+Optionally, after the pull request is merged, you can create a tag on
+this repository for the above registration.
 
 ```
 git tag -a v$(string(ver)) -m "my version $(string(ver))" $(pp.tree_sha)
-git push --tags
+git push v$(string(ver))
 ```
 """
     @debug(cbody)


### PR DESCRIPTION
See #70 

- make clear that the tag should be made after the merge
- only pushed the new tag instead of all of the tags