### PR TITLE
Test registry data access and get_registry

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,5 +1,10 @@
 # This file is machine-generated - editing it directly is not advised
 
+[[AutoHashEquals]]
+git-tree-sha1 = "45bb6705d93be619b81451bb2006b7ee5d4e4453"
+uuid = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
+version = "0.2.0"
+
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
@@ -11,9 +16,9 @@ version = "0.5.3"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "195a3ffcb8b0762684b6821de18f83a16455c6ea"
+git-tree-sha1 = "84aa74986c5b9b898b0d1acaf3258741ee64754f"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "2.0.0"
+version = "2.1.0"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections", "Random", "Serialization", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Stefan Karpinski <stefan@karpinski.org>"]
 version = "0.1.0"
 
 [deps]
+AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/Registrator.jl
+++ b/src/Registrator.jl
@@ -4,9 +4,6 @@ using UUIDs, LibGit2, DataStructures
 
 import Base: PkgId
 
-const DEFAULT_REGISTRY = "https://github.com/JuliaRegistries/General"
-const REGISTRIES = Dict{String,UUID}()
-
 include("slack.jl")
 include("builtin_pkgs.jl")
 include("regedit/RegEdit.jl")

--- a/src/regedit/RegEdit.jl
+++ b/src/regedit/RegEdit.jl
@@ -3,8 +3,11 @@ module RegEdit
 export RegBranch
 export register
 
-import Pkg: Pkg, TOML, GitTools
+using AutoHashEquals
+using Pkg: Pkg, TOML, GitTools
+using UUIDs
 
+include("types.jl")
 include("register.jl")
 include("utils.jl")
 

--- a/src/regedit/RegEdit.jl
+++ b/src/regedit/RegEdit.jl
@@ -4,8 +4,11 @@ export RegBranch
 export register
 
 using AutoHashEquals
+using LibGit2
 using Pkg: Pkg, TOML, GitTools
 using UUIDs
+
+const DEFAULT_REGISTRY_URL = "https://github.com/JuliaRegistries/General"
 
 include("types.jl")
 include("register.jl")

--- a/src/regedit/register.jl
+++ b/src/regedit/register.jl
@@ -110,7 +110,7 @@ errors or warnings that occurred.
 
 # Keyword Arguments
 
-* `registry::String=$DEFAULT_REGISTRY_URL`: the git repository URL for the registry
+* `registry::String="$DEFAULT_REGISTRY_URL"`: the git repository URL for the registry
 * `registry_deps::Vector{String}=[]`: the git repository URLs for any registries containing
     packages depended on by `pkg`
 * `push::Bool=false`: whether to push a registration branch to `registry` for consideration

--- a/src/regedit/types.jl
+++ b/src/regedit/types.jl
@@ -43,7 +43,8 @@ function get_registry(
             git = gitcmd(registry_path, gitconfig)
             run(`$git config remote.origin.url $registry_url`)
             run(`$git checkout -q -f master`)
-            run(`$git fetch -q -P origin master`)
+            # uses config because git versions <2.17.0 did not have the -P option
+            run(`$git -c fetch.pruneTags fetch -q origin master`)
             run(`$git reset -q --hard origin/master`)
         end
     else

--- a/src/regedit/types.jl
+++ b/src/regedit/types.jl
@@ -1,0 +1,91 @@
+@auto_hash_equals struct RegistryData
+    name::String
+    uuid::UUID
+    repo::Union{String, Nothing}
+    description::Union{String, Nothing}
+    packages::Dict{String, Dict{String, Any}}
+    extra::Dict{String, Any}
+end
+
+function RegistryData(
+    name::AbstractString,
+    uuid::Union{UUID, AbstractString};
+    repo::Union{AbstractString, Nothing}=nothing,
+    description::Union{AbstractString, Nothing}=nothing,
+    packages::Dict=Dict(),
+    extras::Dict=Dict(),
+)
+    RegistryData(name, UUID(uuid), repo, description, packages, extras)
+end
+
+function Base.copy(reg::RegistryData)
+    RegistryData(
+        reg.name,
+        reg.uuid,
+        reg.repo,
+        reg.description,
+        deepcopy(reg.packages),
+        deepcopy(reg.extra),
+    )
+end
+
+function parse_registry(io::IO)
+    data = TOML.parse(io)
+
+    name = pop!(data, "name")
+    uuid = pop!(data, "uuid")
+    repo = pop!(data, "repo", nothing)
+    description = pop!(data, "description", nothing)
+    packages = pop!(data, "packages", Dict())
+
+    RegistryData(name, UUID(uuid), repo, description, packages, data)
+end
+
+parse_registry(str::AbstractString) = open(parse_registry, str)
+
+function TOML.print(io::IO, reg::RegistryData)
+    println(io, "name = ", repr(reg.name))
+    println(io, "uuid = ", repr(string(reg.uuid)))
+
+    if reg.repo !== nothing
+        println(io, "repo = ", repr(reg.repo))
+    end
+
+    if reg.description !== nothing
+        # print long-form string if there are multiple lines
+        if '\n' in reg.description
+            print(io, """\n
+                description = \"\"\"
+                $(reg.description)\"\"\"
+                """
+            )
+        else
+            println(io, "description = ", repr(reg.description))
+        end
+    end
+
+    for (k, v) in pairs(reg.extra)
+        TOML.print(io, Dict(k => v), sorted=true)
+    end
+
+    println(io, "\n[packages]")
+    for (uuid, data) in sort!(collect(reg.packages), by=first)
+        print(io, uuid, " = { ")
+        print(io, "name = ", repr(data["name"]))
+        print(io, ", path = ", repr(data["path"]))
+        println(io, " }")
+    end
+
+    nothing
+end
+
+function package_relpath(reg::RegistryData, pkg::Pkg.Types.Project)
+    joinpath("$(uppercase(pkg.name[1]))", pkg.name)
+end
+
+function Base.push!(reg::RegistryData, pkg::Pkg.Types.Project)
+    reg.packages[string(pkg.uuid)] = Dict(
+        "name" => pkg.name, "path" => package_relpath(reg, pkg)
+    )
+    reg
+end

--- a/src/regedit/utils.jl
+++ b/src/regedit/utils.jl
@@ -17,3 +17,10 @@ function write_toml(file::String, data::Dict)
         TOML.print(io, data, sorted=true)
     end
 end
+
+"""
+    registration_branch(pkg::Pkg.Types.Project) -> String
+
+Generate the name for the registry branch used to register the package version.
+"""
+registration_branch(pkg::Pkg.Types.Project) = "register/$(pkg.name)/v$(pkg.version)"

--- a/test/regedit.jl
+++ b/test/regedit.jl
@@ -1,36 +1,57 @@
-import Registrator.RegEdit: write_registry
+using Registrator.RegEdit: RegEdit, parse_registry
 using Pkg.TOML
+using Pkg.Types: Project
 
 using Test
 
 @testset "RegEdit" begin
 
-@testset "write_registry" begin
-    registry = """
-        name = "General"
-        uuid = "23338594-aafe-5451-b93e-139f81909106"
-        repo = "https://github.com/JuliaRegistries/General.git"
+@testset "RegistryData" begin
+    blank = RegEdit.RegistryData("BlankRegistry", "d4e2f5cd-0f48-4704-9988-f1754e755b45")
 
-        description = \"\"\"
-        Official general Julia package registry where people can
-        register any package they want without too much debate about
-        naming and without enforced standards on documentation or
-        testing. We nevertheless encourage documentation, testing and
-        some amount of consideration when choosing package names.
-        \"\"\"
+    example = Project(Dict(
+        "name" => "Example", "uuid" => "7876af07-990d-54b4-ab0e-23690620f79a"
+    ))
 
-        [packages]
-        00701ae9-d1dc-5365-b64a-a3a3ebf5695e = { name = "BioAlignments", path = "B/BioAlignments" }
-        00718b61-6157-5045-8849-3d4c4093d022 = { name = "Convertible", path = "C/Convertible" }
-        0087ddc6-3964-5e57-817f-9937aefb0357 = { name = "MathOptInterfaceMosek", path = "M/MathOptInterfaceMosek" }
-        """
+    @testset "I/O" begin
+        registry = """
+            name = "General"
+            uuid = "23338594-aafe-5451-b93e-139f81909106"
+            repo = "https://github.com/JuliaRegistries/General.git"
 
-    registry_data = TOML.parse(registry)
-    written_registry = sprint(write_registry, registry_data)
-    written_registry_data = TOML.parse(written_registry)
+            description = \"\"\"
+            Official general Julia package registry where people can
+            register any package they want without too much debate about
+            naming and without enforced standards on documentation or
+            testing. We nevertheless encourage documentation, testing and
+            some amount of consideration when choosing package names.
+            \"\"\"
 
-    @test written_registry_data == registry_data
-    @test written_registry == registry
+            [packages]
+            00701ae9-d1dc-5365-b64a-a3a3ebf5695e = { name = "BioAlignments", path = "B/BioAlignments" }
+            00718b61-6157-5045-8849-3d4c4093d022 = { name = "Convertible", path = "C/Convertible" }
+            0087ddc6-3964-5e57-817f-9937aefb0357 = { name = "MathOptInterfaceMosek", path = "M/MathOptInterfaceMosek" }
+            """
+
+        registry_data = parse_registry(IOBuffer(registry))
+        @test registry_data isa RegEdit.RegistryData
+        written_registry = sprint(TOML.print, registry_data)
+        written_registry_data = parse_registry(IOBuffer(written_registry))
+
+        @test written_registry_data == registry_data
+        @test written_registry == registry
+    end
+
+    @testset "Package Operations" begin
+        registry_data = copy(blank)
+
+        @test isempty(registry_data.packages)
+        @test push!(registry_data, example) == registry_data
+        @test length(registry_data.packages) == 1
+        @test haskey(registry_data.packages, string(example.uuid))
+        @test registry_data.packages[string(example.uuid)]["name"] == "Example"
+        @test registry_data.packages[string(example.uuid)]["path"] == joinpath("E", "Example")
+    end
 end
 
 end


### PR DESCRIPTION
This starts the process of testing `register` by testing `get_registry`. 

Introduces RegistryCache for a non-global version of `REGISTRIES` (useful for testing and defining an API). 

Documents `register`. 

Introduces RegistryData for a data structure that represents a Registry.toml's data. Differentiates between operations on the data and reading/writing the data from a file.

We're at about 11% coverage for the package.