### PR TITLE
Misc TOML writing changes, take 2

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -20,12 +20,6 @@ git-tree-sha1 = "84aa74986c5b9b898b0d1acaf3258741ee64754f"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
 version = "2.1.0"
 
-[[DataStructures]]
-deps = ["InteractiveUtils", "OrderedCollections", "Random", "Serialization", "Test"]
-git-tree-sha1 = "ca971f03e146cf144a9e2f2ce59674f5bf0e8038"
-uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.15.0"
-
 [[Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -84,19 +78,13 @@ deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [[MbedTLS]]
-deps = ["BinaryProvider", "Dates", "Libdl", "Random", "Sockets", "Test"]
-git-tree-sha1 = "c93a87da4081a3de781f34e0540175795a2ce83d"
+deps = ["BinaryProvider", "Dates", "Distributed", "Libdl", "Random", "Sockets", "Test"]
+git-tree-sha1 = "2d94286a9c2f52c63a16146bb86fd6cdfbf677c6"
 uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
-version = "0.6.6"
+version = "0.6.8"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
-
-[[OrderedCollections]]
-deps = ["Random", "Serialization", "Test"]
-git-tree-sha1 = "85619a3f3e17bb4761fe1b1fd47f0e979f964d5b"
-uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.0.2"
 
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]

--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ version = "0.1.0"
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
-DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"

--- a/src/Registrator.jl
+++ b/src/Registrator.jl
@@ -1,6 +1,6 @@
 module Registrator
 
-using UUIDs, LibGit2, DataStructures
+using UUIDs, LibGit2
 
 import Base: PkgId
 

--- a/src/regedit/RegEdit.jl
+++ b/src/regedit/RegEdit.jl
@@ -7,7 +7,6 @@ using AutoHashEquals
 using LibGit2
 using Pkg: Pkg, TOML, GitTools
 using UUIDs
-using DataStructures
 
 const DEFAULT_REGISTRY_URL = "https://github.com/JuliaRegistries/General"
 

--- a/src/regedit/register.jl
+++ b/src/regedit/register.jl
@@ -208,11 +208,8 @@ function register(
         version_info = Dict{String,Any}("git-tree-sha1" => string(tree_hash))
         versions_data[string(pkg.version)] = version_info
 
-        vnlist = sort([(VersionNumber(k), v) for (k, v) in versions_data])
-        vslist = [(string(k), v) for (k, v) in vnlist]
-
         open(versions_file, "w") do io
-            TOML.print(io, OrderedDict(vslist))
+            TOML.print(io, versions_data; sorted=true, by=x->VersionNumber(x))
         end
 
         # update package data: deps file

--- a/src/regedit/register.jl
+++ b/src/regedit/register.jl
@@ -105,7 +105,7 @@ errors or warnings that occurred.
 # Arguments
 
 * `package_repo::String`: the git repository URL for the package to be registered
-* `pkg::Pkt.Types.Project`: the parsed Project.toml file for the package to be registered
+* `pkg::Pkg.Types.Project`: the parsed Project.toml file for the package to be registered
 * `tree_hash::String`: the tree hash (not commit hash) of the package revision to be registered
 
 # Keyword Arguments
@@ -185,11 +185,14 @@ function register(
 
         # update package data: package file
         @debug("update package data: package file")
-        package_info = filter(((k,v),)->!(v isa Dict), Pkg.Types.destructure(pkg))
-        delete!(package_info, "version")
-        package_info["repo"] = package_repo
+        package_info = Dict("name" => pkg.name,
+                            "uuid" => string(pkg.uuid),
+                            "repo" => package_repo)
         package_file = joinpath(package_path, "Package.toml")
-        write_toml(package_file, package_info)
+        open(package_file, "w") do io
+            TOML.print(io, package_info; sorted=true,
+                by = x -> x == "name" ? 1 : x == "uuid" ? 2 : 3)
+        end
 
         # update package data: versions file
         @debug("update package data: versions file")

--- a/src/regedit/utils.jl
+++ b/src/regedit/utils.jl
@@ -10,15 +10,6 @@ function gitcmd(path::String, gitconfig::Dict)
 end
 
 """
-Write TOML data (with sorted keys).
-"""
-function write_toml(file::String, data::Dict)
-    open(file, "w") do io
-        TOML.print(io, data, sorted=true)
-    end
-end
-
-"""
     registration_branch(pkg::Pkg.Types.Project) -> String
 
 Generate the name for the registry branch used to register the package version.


### PR DESCRIPTION
Fixes https://github.com/JuliaComputing/Registrator.jl/pull/92#issuecomment-484609860 by printing the dict directly. Demo to show that it actually works this time :tada: 
```
julia> versions_file = "/home/fredrik/.julia/registries/General/L/Literate/Versions.toml";

shell> cat $versions_file
["0.1.0"]
git-tree-sha1 = "710421f148e853a2dec017e98af48c4eafa4f2a8"

[...]

["1.1.0"]
git-tree-sha1 = "021e2e3106713e22a7f3769ebf9f2f4469670444"

julia> versions_data = isfile(versions_file) ? TOML.parsefile(versions_file) : Dict();

julia> versions_data = isfile(versions_file) ? TOML.parsefile(versions_file) : Dict();

julia> open(versions_file, "w") do io
           TOML.print(io, versions_data; sorted=true, by=x->VersionNumber(x))
       end;

shell> cat $versions_file
["0.1.0"]
git-tree-sha1 = "710421f148e853a2dec017e98af48c4eafa4f2a8"

[...]

["1.1.0"]
git-tree-sha1 = "021e2e3106713e22a7f3769ebf9f2f4469670444"
```