### PR TITLE
Remove use of some Base functions in check_version.

### DIFF
--- a/src/regedit/register.jl
+++ b/src/regedit/register.jl
@@ -69,16 +69,14 @@ function write_registry(registry_path::String, reg::RegistryData)
     end
 end
 
-import Base: thismajor, thisminor, nextmajor, nextminor, thispatch, nextpatch, lowerbound
-
 # Returns Tuple (error, warning)
 function check_version(existing::Vector{VersionNumber}, ver::VersionNumber)
+    @assert issorted(existing)
     if isempty(existing)
-        if all([lowerbound(v) <= ver <= v for v in [v"0.0.1", v"0.1", v"1"]])
+        if !(ver in [v"0.0.1", v"0.1", v"1"])
             return nothing, "This looks like a new registration that registers version $ver. Ideally, you should register an initial release with 0.0.1, 0.1.0 or 1.0.0 version numbers"
         end
     else
-        issorted(existing) || (existing = sort(existing))
         idx = searchsortedlast(existing, ver)
         if idx <= 0
             return "Version $ver less than least existing version $(existing[1])", nothing
@@ -88,8 +86,9 @@ function check_version(existing::Vector{VersionNumber}, ver::VersionNumber)
         if ver == prv
             return "Version $ver already exists", nothing
         end
-        nxt = thismajor(ver) != thismajor(prv) ? nextmajor(prv) :
-              thisminor(ver) != thisminor(prv) ? nextminor(prv) : nextpatch(prv)
+        nxt = ver.major != prv.major ? VersionNumber(prv.major+1, 0, 0) :
+              ver.minor != prv.minor ? VersionNumber(prv.major, prv.minor+1, 0) :
+              VersionNumber(prv.major, prv.minor, prv.patch+1)
         if ver > nxt
             return nothing, "Version $ver skips over $nxt"
         end


### PR DESCRIPTION
Those functions does not belong in Base IMO, so better not use them and we can remove them from there (https://github.com/JuliaLang/julia/compare/cb85f840a533f79741b79dfd94a00d9581f22983..2e0d6b75356f101ee7f743bbb74cf7d6ce4f8a79)