### PR TITLE
Enable organizational membership check for release rights

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,14 @@ Check that your package conforms to the required `Project.toml` structure found 
 
 ### Details for triggering JuliaRegistrator (for step 2 above)
 
-#### If you are a collaborator on the repo
-
 Either:
 
 1. Open an issue and add ` @JuliaRegistrator register() ` as a comment.  You can re-trigger the registrator by commenting ` @JuliaRegistrator register() ` again (in case registrator reports an error or to make changes).
 2. Add a comment to a commit and say ` @JuliaRegistrator register() `.
 
-#### If you are not a collaborator
+*Note*: Only *collaborators* on the package repository and *public members* on the organization the package is under are allowed to register. If you are not a collaborator, you can request a collaborator trigger registrator in a GitHub issue or a comment on a commit.
 
-You can request a collaborator trigger registrator in a GitHub issue or a comment on a commit.
+If you want to register as a private member you should host your own instance of Registrator, see [docs.md](https://github.com/JuliaComputing/Registrator.jl/blob/master/docs.md)
 
 ### Note on git tags and GitHub releases
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Registrator is a GitHub app that automates creation of registration pull request
 First, install the app on your package(s) as mentioned above.  The procedure for registering a new package is the same as for releasing a new version.
 
 1. Set the [Project.toml](Project.toml) version field in your repository to your new desired `version`.
-2. Comment `@JuliaRegistrator register()` on the commit/branch you want to release (e.g. like [here](https://github.com/JuliaComputing/Registrator.jl/issues/61#issuecomment-483486641) or [here](https://github.com/chakravala/Grassmann.jl/commit/3c3a92610ebc8885619f561fe988b0d985852fce#commitcomment-33233149)).
+2. Comment `@JuliaRegistrator register()` on the commit/branch you want to register (e.g. like [here](https://github.com/JuliaComputing/Registrator.jl/issues/61#issuecomment-483486641) or [here](https://github.com/chakravala/Grassmann.jl/commit/3c3a92610ebc8885619f561fe988b0d985852fce#commitcomment-33233149)).
 3. If something is incorrect, adjust, and redo step 2.
 4. Finally, either rely on [TagBot](https://github.com/apps/julia-tagbot) to tag and make a github release or alternatively tag the release manually.
 

--- a/docs.md
+++ b/docs.md
@@ -39,6 +39,11 @@ If you do host your own Registrator, you can set it up on your private package:
 * Add the GitHub user that you mention in the configuration file as a collaborator to the private Registry and package.
 * Install the GitHub app on the repository.
 
+## Allow private organization members to register
+
+* Set `check_private_membership` to `true` in the configuration file
+* Add the GitHub user that you mention in the configuration file as a member to the organization(s)
+
 ## The approved() call
 
 The approved() call is a comment you make on a Registry PR. This is *disabled* on the public Registrator as it requires write access to the repository. It does the following:

--- a/image/scripts/sample.toml
+++ b/image/scripts/sample.toml
@@ -61,6 +61,11 @@ disable_approval_process = false    # If set to true this will enable the approv
 disable_private_registrations = true    # If set to false this will enable private packages
                                 # to be registered.
 
+check_private_membership = false    # If set to true Registrator will allow private members
+                                # of the organization of the package to register. Note that
+                                # for this to work the `user` mentioned above must be a
+                                # member of the organization.
+
 # Additional registries to look into for `[deps]` and `[compat]`
 registry_deps = ["https://github.com/JuliaRegistries/General"]
 

--- a/src/Server.jl
+++ b/src/Server.jl
@@ -412,13 +412,7 @@ function is_comment_by_org_owner_or_member(event)
     return any(userorgs.==org)
 end
 
-function has_release_rights(event)
-    if is_comment_by_collaborator(event)
-        return true
-    else
-        return is_owned_by_organization(event) && is_comment_by_org_owner_or_member(event)
-    end
-end
+has_release_rights(event) = is_comment_by_collaborator(event) || is_owned_by_organization(event) && is_comment_by_org_owner_or_member(event)
 
 function is_pull_request(payload)
     haskey(payload, "pull_request") || haskey(payload, "issue") && haskey(payload["issue"], "pull_request")

--- a/src/Server.jl
+++ b/src/Server.jl
@@ -408,8 +408,11 @@ function is_comment_by_org_owner_or_member(event)
     @debug("Checking if comment is by repository parent organization owner or member")
     org = event.repository.owner.login
     user = get_user_login(event.payload)
-    userorgs = orgs(user)
-    return any(userorgs.==org)
+    if get(config["registrator"], "check_private_membership", false)
+        return GitHub.check_membership(org, user; auth=get_user_auth())
+    else
+        return GitHub.check_membership(org, user; public_only=true)
+    end
 end
 
 has_release_rights(event) = is_comment_by_collaborator(event) || is_owned_by_organization(event) && is_comment_by_org_owner_or_member(event)

--- a/src/Server.jl
+++ b/src/Server.jl
@@ -397,8 +397,7 @@ function is_comment_by_org_owner_or_member(event)
     org = event.repository.owner.login
     user = get_user_login(event.payload)
     userorgs = orgs(user)
-    any(userorgs.=org)
-    return any(userorgs.=org)
+    return any(userorgs.==org)
 end
 
 function has_release_rights(event)

--- a/src/Server.jl
+++ b/src/Server.jl
@@ -401,11 +401,11 @@ function is_comment_by_org_owner_or_member(event)
 end
 
 function has_release_rights(event)
-  if is_owned_by_organization(event)
-    return is_comment_by_org_owner_or_member(event)
-  else
-    return is_comment_by_collaborator(event)
-  end
+    if is_comment_by_collaborator(event)
+        return true
+    else
+        return is_owned_by_organization(event) && is_comment_by_org_owner_or_member(event)
+    end
 end
 
 function is_pull_request(payload)


### PR DESCRIPTION
This should fix the inability of *Members* (as opposed to *Owners*) of org-owned repos to invoke `@JuliaRegistrator`, even if they have release rights.

Designed to handle both repos owned by organizations through membership, and previous method for collaborators on privately owned repos

**N.B.** I haven't tested this code locally, as I was unsure how to on my local machine