### PR TITLE
Mention TagBot in registration notice

### DIFF
--- a/src/Server.jl
+++ b/src/Server.jl
@@ -783,11 +783,9 @@ function make_pull_request(pp::ProcessedParams, rp::RequestParams, rbrn::RegBran
     cbody = """
         Registration pull request $msg: [$(repo)/$(pr.number)]($(pr.html_url))
 
-        After the above pull request is merged, it is recommended that a tag is created on this 
-        repository for the registered package version.
+        After the above pull request is merged, it is recommended that a tag is created on this repository for the registered package version.
     
-        This will be done automatically if [Julia TagBot](https://github.com/apps/julia-tagbot) is 
-        installed, or can be done manually through the github interface or via:
+        This will be done automatically if [Julia TagBot](https://github.com/apps/julia-tagbot) is installed, or can be done manually through the github interface, or via:
         ```
         git tag -a v$(string(ver)) -m "<description of version>" $(pp.sha)
         git push origin v$(string(ver))

--- a/src/Server.jl
+++ b/src/Server.jl
@@ -783,8 +783,11 @@ function make_pull_request(pp::ProcessedParams, rp::RequestParams, rbrn::RegBran
     cbody = """
         Registration pull request $msg: [$(repo)/$(pr.number)]($(pr.html_url))
 
-        After the above pull request is merged, it is recommended that you create
-        a tag on this repository for the registered package version:
+        After the above pull request is merged, it is recommended that a tag is created on this 
+        repository for the registered package version.
+    
+        This will be done automatically if [Julia TagBot](https://github.com/apps/julia-tagbot) is 
+        installed, or can be done manually through the github interface or via:
         ```
         git tag -a v$(string(ver)) -m "<description of version>" $(pp.sha)
         git push origin v$(string(ver))


### PR DESCRIPTION
An update to mention TagBot:

----
Registration pull request $msg: [$(repo)/$(pr.number)]($(pr.html_url))

After the above pull request is merged, it is recommended that a tag is created on this repository for the registered package version.
    
This will be done automatically if [Julia TagBot](https://github.com/apps/julia-tagbot) is installed, or can be done manually through the github interface or via:
```
git tag -a v$(string(ver)) -m "<description of version>" $(pp.sha)
git push origin v$(string(ver))
```
---



Perhaps the message could be shorter? or could Registrator check for TagBot installation?